### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Mainly Question Answering,Machine comprehension,Sentiment Analysis...
 - Contributions are welcomed.
 
-##Table of Contents
+## Table of Contents
 - [Python](#python)
 - [Tensorflow](#tensorflow)
 - [Theano](#theano)
@@ -13,13 +13,13 @@
 - [Deep Reinforcement Learning](#Deep Reinforcement Learning)
 
 <a name="python" />
-##Python
+## Python
 - [context2vec: Learning Generic Context Embedding with Bidirectional LSTM](https://github.com/orenmel/context2vec)
 - [Deep Unordered Composition Rivals Syntactic Methods for Text Classification(Deep Averaging Networks ACL2015)](https://github.com/miyyer/dan)
 
 
 <a name="tensorflow" />
-##Tensorflow
+## Tensorflow
 - [Neural Turing Machine(NMT)](https://github.com/carpedm20/NTM-tensorflow).Taehoon Kim’s(Tensorflow)
 - [Neural Turing Machine(NMT)](https://github.com/kaishengtai/torch-ntm). Kai Sheng Tai’s (Torch)
 - [Neural Turing Machine(NMT)](https://github.com/shawntan/neural-turing-machines)Shawn Tan’s (Thenao)
@@ -44,7 +44,7 @@
 - [A statistical natural language generator for spoken dialogue systems(SIGDIAL 2016 short paper)](https://github.com/UFAL-DSG/tgen)
 
 <a name="theano" />
-##Theano
+## Theano
 - [ End-To-End Memory Networks, formerly known as Weakly Supervised Memory Networks](https://github.com/npow/MemN2N)
 - [Memory Networks](https://github.com/npow/MemNN)
 - [Dynamic Memory Networks](https://github.com/swstarlab/DynamicMemoryNetworks)
@@ -66,11 +66,11 @@
 - [Siamese-LSTM - Siamese Recurrent Neural network with LSTM for evaluating semantic similarity between sentences.（AAAI2016））](https://github.com/aditya1503/Siamese-LSTM)
 
 <a name="keras"/>
-##Keras
+## Keras
 - [Learning text representation using recurrent convolutional neural network with highway layers](https://github.com/wenying45/deep_learning_tutorial/tree/master/rcnn-hw)
 
 <a name="torch"/>
-##Torch
+## Torch
 - [Sequence-to-sequence model with LSTM encoder/decoders and attention](https://github.com/harvardnlp/seq2seq-attn)
 - [Chains of Reasoning over Entities, Relations, and Text using Recurrent Neural Networks](https://github.com/rajarshd/ChainsOfReasoning/tree/master/model)
 - [Recurrent Memory Network for Language Modeling](https://github.com/ketranm/RMN)
@@ -84,17 +84,17 @@
 - [The Goldilocks Principle: Reading Children's Books with Explicit Memory Representations, Hill et al., ICLR 2016.](https://github.com/ganeshjawahar/torch-teacher)
 
 <a name="matlab">
-##Matlab
+## Matlab
 - [When Are Tree Structures Necessary for Deep Learning of Representations](https://github.com/jiweil/Sequence-Models-on-Stanford-Treebank)
  
  
 <A name="Deep Reinforcement Learning">
-##Deep Reinforcement Learning
+## Deep Reinforcement Learning
 
 
-##===========================================
+## ===========================================
 <A name="mldptt">
-##machine learning and deep learning tutorials, articles and other resources
+## machine learning and deep learning tutorials, articles and other resources
 - [machine learning and deep learning tutorials, articles and other resources](https://github.com/ujjwalkarn/Machine-Learning-Tutorials)
 - [Knowledge Graph Embeddings including TransE, TransH, TransR and PTransE](https://github.com/thunlp/KG2E)
 - [【论文:深度学习NLP的可视化理解】《Visualizing and Understanding Neural Models in NLP》J Li, X Chen, E Hovy, D Jurafsky (2015) ](https://github.com/jiweil/Visualizing-and-Understanding-Neural-Models-in-NLP)
@@ -106,6 +106,6 @@
 
 
 <A name="people">
-##People
+## People
 -[carpedm20](https://github.com/carpedm20)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
